### PR TITLE
implement redis stream buffer

### DIFF
--- a/SAPHana/Dockerfile
+++ b/SAPHana/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.15.6-alpine
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN cd SAPHana && go build -o main
+
+CMD ["./SAPHana/main"]
+

--- a/SAPHana/docker-compose.yml
+++ b/SAPHana/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  producer:
+    build:
+      context: .
+      dockerfile: ./redisstream/Dockerfile
+    environment:
+      - USERNAME=CHANGEME
+      - PASSWORD=CHANGEME
+      - API_URL=https://api.infinimesh.cloud
+      - TOKEN_REFRESH_INTERVAL_SECS=3600
+      - OBJECT_REFRESH_INTERVAL_SECS=600
+      - REDIS_ADDR=redis:6379
+    restart: always
+  consumer:
+    build:
+      context: .
+      dockerfile: ./SAPHana/Dockerfile
+    environment:
+      - REDIS_ADDR=redis:6379
+    restart: always
+  redis:
+    image: redis:6.0.9-alpine
+    ports:
+      - 6379:6379

--- a/SAPHana/go.mod
+++ b/SAPHana/go.mod
@@ -1,0 +1,13 @@
+module github.com/InfiniteDevices/plugins/SAPHana
+
+go 1.15
+
+replace (
+	github.com/InfiniteDevices/plugins/pkg => ../pkg
+	github.com/InfiniteDevices/plugins/redisstream => ../redisstream
+)
+
+require (
+	github.com/InfiniteDevices/plugins/redisstream v0.0.0
+	github.com/gomodule/redigo v1.8.3
+)

--- a/SAPHana/go.sum
+++ b/SAPHana/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
+github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/SAPHana/main.go
+++ b/SAPHana/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/InfiniteDevices/plugins/redisstream/consumer"
+	"github.com/gomodule/redigo/redis"
+)
+
+const (
+	envRedisAddr = "REDIS_ADDR"
+)
+
+func main() {
+	redisPool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", os.Getenv(envRedisAddr))
+	}}
+	c := consumer.New(redisPool)
+	for event := range c.Consume() {
+		log.Println("received event:", event)
+	}
+}

--- a/redisstream/Dockerfile
+++ b/redisstream/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.15.6-alpine
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN cd redisstream && go build -o main
+
+CMD ["./redisstream/main"]
+

--- a/redisstream/consumer/consumer.go
+++ b/redisstream/consumer/consumer.go
@@ -1,0 +1,137 @@
+package consumer
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"runtime/debug"
+	"time"
+
+	"github.com/InfiniteDevices/plugins/pkg/api"
+	"github.com/gomodule/redigo/redis"
+)
+
+type RedisStreamEvent struct {
+	ID          string
+	DeviceEvent *DeviceEvent
+}
+
+type DeviceEvent struct {
+	Object api.Object
+	State  api.DeviceState
+}
+
+type Consumer interface {
+	Consume() <-chan *DeviceEvent
+}
+
+type consumerImpl struct {
+	redis *redis.Pool
+	name  string
+}
+
+func New(pool *redis.Pool) Consumer {
+	hn, _ := os.Hostname()
+	return &consumerImpl{
+		redis: pool,
+		name:  hn,
+	}
+}
+
+func (i *consumerImpl) Consume() <-chan *DeviceEvent {
+	i.createGroupIfNotExists()
+	ret := make(chan *DeviceEvent)
+	go func() {
+		for {
+			shouldCooldown := i.loop(ret)
+			if shouldCooldown {
+				time.Sleep(time.Second)
+			}
+		}
+	}()
+	return ret
+}
+
+func (i *consumerImpl) loop(ch chan<- *DeviceEvent) bool {
+	conn := i.redis.Get()
+	defer conn.Close()
+	reply, err := conn.Do("XREADGROUP", "GROUP", "group", i.name, "STREAMS", "objects", ">")
+	if err != nil {
+		log.Printf("error on XREAD: %v\n", err)
+		return true
+	}
+	if reply == nil {
+		return true
+	}
+	events := parseReply(reply)
+	for _, e := range events {
+		if _, err := conn.Do("XACK", "objects", "group", e.ID); err != nil {
+			log.Printf("error on XACK: %v\n", err)
+		}
+		ch <- e.DeviceEvent
+	}
+	return false
+}
+
+func (i *consumerImpl) createGroupIfNotExists() {
+	conn := i.redis.Get()
+	defer conn.Close()
+	_, _ = conn.Do("XGROUP", "CREATE", "objects", "group", "$")
+}
+
+func parseReply(reply interface{}) []RedisStreamEvent {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("unexpected error when parsing reply: %v\n", err)
+			debug.PrintStack()
+		}
+	}()
+
+	ret := []RedisStreamEvent{}
+	streamAndEventss := reply.([]interface{})
+	for _, se := range streamAndEventss {
+		streamAndEvents := se.([]interface{})
+		events := streamAndEvents[1].([]interface{})
+		for _, e := range events {
+			event := e.([]interface{})
+			eventID := string(event[0].([]byte))
+			eventData := event[1].([]interface{})
+			ret = append(ret, RedisStreamEvent{
+				ID:          eventID,
+				DeviceEvent: parseEventData(eventData),
+			})
+		}
+	}
+	return ret
+}
+
+func parseEventData(eventData []interface{}) *DeviceEvent {
+	if eventData == nil {
+		return nil
+	}
+	ret := &DeviceEvent{}
+	for i := 0; i < len(eventData); i += 2 {
+		k := string(eventData[i].([]byte))
+		v := eventData[i+1].([]byte)
+		switch k {
+		case "object":
+			obj := api.Object{}
+			err := json.Unmarshal(v, &obj)
+			if err != nil {
+				log.Printf("unexpected error when unmarshaling object: %v\n", err)
+				continue
+			}
+			ret.Object = obj
+		case "state":
+			state := api.DeviceState{}
+			err := json.Unmarshal(v, &state)
+			if err != nil {
+				log.Printf("unexpected error when unmarshaling object: %v\n", err)
+			}
+			ret.State = state
+		default:
+			log.Printf("unexpected key when parsing event data: %v\n", k)
+		}
+	}
+	return ret
+}

--- a/redisstream/go.mod
+++ b/redisstream/go.mod
@@ -1,0 +1,11 @@
+module github.com/InfiniteDevices/plugins/redisstream
+
+go 1.15
+
+require (
+	github.com/InfiniteDevices/plugins/pkg v0.0.0
+	github.com/gomodule/redigo v1.8.3
+	github.com/stretchr/testify v1.6.1 // indirect
+)
+
+replace github.com/InfiniteDevices/plugins/pkg => ../pkg

--- a/redisstream/go.sum
+++ b/redisstream/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
+github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/redisstream/main.go
+++ b/redisstream/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/InfiniteDevices/plugins/pkg/api"
+	"github.com/InfiniteDevices/plugins/pkg/wrappers"
+	"github.com/gomodule/redigo/redis"
+)
+
+const (
+	envApiUrl                    = "API_URL"
+	envUsername                  = "USERNAME"
+	envPassword                  = "PASSWORD"
+	envTokenRefreshIntervalSecs  = "TOKEN_REFRESH_INTERVAL_SECS"
+	envObjectRefreshIntervalSecs = "OBJECT_REFRESH_INTERVAL_SECS"
+	envRedisAddr                 = "REDIS_ADDR"
+)
+
+func main() {
+	redisPool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", os.Getenv(envRedisAddr))
+	}}
+	username := os.Getenv(envUsername)
+	password := os.Getenv(envPassword)
+	apiUrl := os.Getenv(envApiUrl)
+	tokenRefreshIntervalSecsStr := os.Getenv(envTokenRefreshIntervalSecs)
+	tokenRefreshIntervalSecs, err := strconv.Atoi(tokenRefreshIntervalSecsStr)
+	if err != nil {
+		log.Fatalf("invalid %s value: %s", envTokenRefreshIntervalSecs, tokenRefreshIntervalSecsStr)
+	}
+	objectRefreshIntervalSecsStr := os.Getenv(envObjectRefreshIntervalSecs)
+	objectRefreshIntervalSecs, err := strconv.Atoi(objectRefreshIntervalSecsStr)
+	if err != nil {
+		log.Fatalf("invalid %s value: %s", envObjectRefreshIntervalSecs, objectRefreshIntervalSecsStr)
+	}
+	apiHandler := api.NewHandler(
+		api.NewTokenHandler(username, password, apiUrl, time.Duration(tokenRefreshIntervalSecs)*time.Second),
+		apiUrl,
+	)
+
+	wrappers.NewObjectManager(
+		apiHandler,
+		(&objectWorkerFactory{
+			api:   apiHandler,
+			redis: redisPool,
+		}).NewObjectWorker,
+		time.Duration(objectRefreshIntervalSecs)*time.Second,
+	).Start()
+}
+
+type objectWorkerFactory struct {
+	api   api.Handler
+	redis *redis.Pool
+}
+
+func (f *objectWorkerFactory) NewObjectWorker(obj api.Object) wrappers.Process {
+	return &objectWorker{
+		obj:   obj,
+		api:   f.api,
+		redis: f.redis,
+		done:  make(chan struct{}),
+	}
+}
+
+type objectWorker struct {
+	obj   api.Object
+	api   api.Handler
+	redis *redis.Pool
+	done  chan struct{}
+}
+
+func (w *objectWorker) Start() {
+	ch, err := w.api.GetDevicesStateStream(w.obj.UID)
+	if err != nil {
+		log.Printf("error on get devices state stream: %s\n", err)
+		return
+	}
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case state := <-ch:
+			if state == nil {
+				log.Printf("received nil state for object %v", w.obj)
+				continue
+			}
+			objJson, _ := json.Marshal(w.obj)
+			stateJson, _ := json.Marshal(state.Result.ReportedState)
+			conn := w.redis.Get()
+			reply, err := conn.Do("XADD", "objects", "*", "object", string(objJson), "state", string(stateJson))
+			conn.Close()
+			if err != nil {
+				log.Printf("failed to stream object: object=%v err=%v\n", w.obj, err)
+			} else {
+				log.Printf("successfully streamed object: object=%v reply=%v\n", w.obj, string(reply.([]byte)))
+			}
+		}
+	}
+}
+
+func (w *objectWorker) Stop() {
+	close(w.done)
+}


### PR DESCRIPTION
adds a new directory `redisstream`, which implements producer/consumer logic for a temporary redis buffer when streaming device state data from the Infinimesh API. See `SAPHana/docker-compose.yml` for example usage