### PR TITLE
implement SAP HANA connector

### DIFF
--- a/SAPHana/docker-compose.yml
+++ b/SAPHana/docker-compose.yml
@@ -18,6 +18,11 @@ services:
       context: .
       dockerfile: ./SAPHana/Dockerfile
     environment:
+      - SAPHANA_INITDB=true
+      - SAPHANA_USERNAME=CHANGEME
+      - SAPHANA_PASSWORD=CHANGEME
+      - SAPHANA_HOST=CHANGEME
+      - SAPHANA_PORT=443
       - REDIS_ADDR=redis:6379
     restart: always
   redis:

--- a/SAPHana/go.mod
+++ b/SAPHana/go.mod
@@ -9,5 +9,6 @@ replace (
 
 require (
 	github.com/InfiniteDevices/plugins/redisstream v0.0.0
+	github.com/SAP/go-hdb v0.102.6
 	github.com/gomodule/redigo v1.8.3
 )

--- a/SAPHana/go.sum
+++ b/SAPHana/go.sum
@@ -1,3 +1,5 @@
+github.com/SAP/go-hdb v0.102.6 h1:1pQm0EqvbPJNjvC+i/7sDxnhq8qmKFNwDFyaOqGMDbk=
+github.com/SAP/go-hdb v0.102.6/go.mod h1:QWXWqf1U0JcTvGyvncwwmrMO5T6z4Wo4B6QktCN4SRo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
@@ -9,6 +11,16 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/SAPHana/main.go
+++ b/SAPHana/main.go
@@ -1,23 +1,92 @@
 package main
 
 import (
+	"crypto/tls"
+	"database/sql"
+	"encoding/json"
 	"log"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/InfiniteDevices/plugins/redisstream/consumer"
+	"github.com/SAP/go-hdb/driver"
 	"github.com/gomodule/redigo/redis"
 )
 
 const (
-	envRedisAddr = "REDIS_ADDR"
+	envSapHanaInitDB   = "SAPHANA_INITDB"
+	envSapHanaUsername = "SAPHANA_USERNAME"
+	envSapHanaPassword = "SAPHANA_PASSWORD"
+	envSapHanaHost     = "SAPHANA_HOST"
+	envSapHanaPort     = "SAPHANA_PORT"
+	envRedisAddr       = "REDIS_ADDR"
 )
 
 func main() {
 	redisPool := &redis.Pool{Dial: func() (redis.Conn, error) {
 		return redis.Dial("tcp", os.Getenv(envRedisAddr))
 	}}
+	db := newSapHanaDB(
+		os.Getenv(envSapHanaHost),
+		os.Getenv(envSapHanaPort),
+		os.Getenv(envSapHanaUsername),
+		os.Getenv(envSapHanaPassword),
+	)
+	shouldInitDB, _ := strconv.ParseBool(os.Getenv(envSapHanaInitDB))
+	if shouldInitDB {
+		if err := initDB(db); err != nil {
+			log.Printf("failed to initialise db: err=%v\n", err)
+		}
+	}
 	c := consumer.New(redisPool)
 	for event := range c.Consume() {
-		log.Println("received event:", event)
+		if event == nil {
+			log.Println("received nil event")
+			continue
+		}
+		err := insertDeviceEvent(db, event)
+		if err != nil {
+			log.Printf("failed to insert event to SAP HANA: err=%v", err)
+		} else {
+			log.Println("inserted event to SAP HANA:", event)
+		}
 	}
+}
+
+// for some reason, connecting to the db via connection string as mentioned in
+// the go-hdb driver documentation doesn't work, thus we opt for this
+// alternative connection method
+//
+// also see https://stackoverflow.com/questions/58698188
+func newSapHanaDB(host, port, username, password string) *sql.DB {
+	c := driver.NewBasicAuthConnector(host+":"+port, username, password)
+	tlsConfig := tls.Config{
+		InsecureSkipVerify: false,
+		ServerName:         host,
+	}
+	c.SetTLSConfig(&tlsConfig)
+	return sql.OpenDB(c)
+}
+
+// initDB initialises the required relations in SAP HANA for storage
+//
+// ideally we would want to use the SAP HANA JSON Docstore, but the cloud
+// offering doesn't support it as of time of writing. Here we opt for an
+// alternative where we store retrieved data as a JSON string in a table
+//
+// also see https://answers.sap.com/questions/13207475/
+func initDB(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE devices (uid varchar(1000), timestamp timestamp, version varchar(1000), data varchar(5000), PRIMARY KEY (uid, timestamp));`)
+	return err
+}
+
+func insertDeviceEvent(db *sql.DB, event *consumer.DeviceEvent) error {
+	t, err := time.Parse("2006-01-02T15:04:05.000Z", event.State.Timestamp)
+	if err != nil {
+		return err
+	}
+	jsonData, _ := json.Marshal(event.State.Data)
+	_, err = db.Exec("INSERT INTO devices (uid, timestamp, version, data) VALUES (?, ?, ?, ?)", event.Object.UID, t, event.State.Version, string(jsonData))
+	return err
 }


### PR DESCRIPTION
implements the SAP HANA connector

there are some notes about the chosen schema, as noted in the code:

```
// ideally we would want to use the SAP HANA JSON Docstore, but the cloud
// offering doesn't support it as of time of writing. Here we opt for an
// alternative where we store retrieved data as a JSON string in a table
//
// also see https://answers.sap.com/questions/13207475/
```

also adds a few bug fixes:
- add `MKSTREAM` option to `XGROUP CREATE` command in redis stream consumer. This ensures that the stream exists for `XREADGROUP` to work. Previously if the consumer started before the producer, the stream doesn't yet exist, thus causing `XGROUP CREATE` to fail which in turn causes no data to be read
- continuously retry connection to device state stream when there's no data or if the connection breaks. In the new behaviour the connection should only be closed after stopping the program