### PR TITLE
Adding Redis Application Plugin 

### DIFF
--- a/timeseries/docker-compose.yml
+++ b/timeseries/docker-compose.yml
@@ -25,3 +25,4 @@ services:
       - ./timeseries/provisioning:/etc/grafana/provisioning
     environment:
       - GF_INSTALL_PLUGINS=redis-datasource
+      - GF_INSTALL_PLUGINS=redis-app


### PR DESCRIPTION
Starting Grafana 7.0 and later with a new plug-in platform supported, there is a new plug-in introduced by Redis Labs so called "Redis Application". The Redis Application, is a plug-in for Grafana that provides custom panels for Redis Data Source.

All you can enable it by adding the below environmental variable to docker-compose file:

```
- GF_INSTALL_PLUGINS=redis-app
```

More details: https://grafana.com/grafana/plugins/redis-app

